### PR TITLE
feat(space): consolidate card info into a 2-column card overview in d…

### DIFF
--- a/src/components/page/space/components/SpaceDetailContent.tsx
+++ b/src/components/page/space/components/SpaceDetailContent.tsx
@@ -2,7 +2,7 @@ import { SpaceCoinHistoryMeta, SpaceDetail } from '@/client/types';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Bell, CalendarClock, Cat, Copy, CreditCard, Flag, History, Home, Trash2, type LucideIcon } from 'lucide-react';
+import { Cat, Copy, Flag, History, Home, Trash2, type LucideIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import {
   buildRoomCategorySummary,
@@ -123,19 +123,12 @@ function SpaceDetailContent({ detail, copyId }: SpaceDetailContentProps) {
         <SectionTitle>상세 정보</SectionTitle>
         <div className='grid grid-cols-1 gap-x-6 gap-y-6 rounded-xl border border-slate-200/80 bg-white p-6 shadow-sm sm:grid-cols-2 xl:grid-cols-3'>
           <DetailField icon={Cat} label='펫 이름 / 종류' value={petNameValue} />
-          <DetailField icon={Bell} label='카드 발급 시간' value={detail.spaceInfo?.noticeTime || '-'} />
           <DetailField
             icon={Flag}
             label='시작일'
             value={detail.spaceInfo?.startedAt ? formatDate(detail.spaceInfo.startedAt, 'YY.MM.DD') : '-'}
           />
           <DetailField icon={Home} label='방 구성' value={roomSummary ?? `방 ${roomCount}`} />
-          <DetailField
-            icon={CreditCard}
-            label='카드 / 최근 발급'
-            value={`카드 ${detail.cardOrder ?? 0} · ${detail.latestCardIssuedAt ? formatDate(detail.latestCardIssuedAt, 'YY.MM.DD HH:mm') : '발급 없음'}`}
-          />
-          <DetailField icon={CalendarClock} label='다음 카드 생성 기준' value={detail.cardGenDate ?? '-'} />
           <DetailField icon={History} label='최근 수정일' value={detail.updatedAt ? formatDate(detail.updatedAt) : '-'} />
           <DetailField
             icon={Trash2}

--- a/src/components/page/space/components/SpaceDetailSheet.tsx
+++ b/src/components/page/space/components/SpaceDetailSheet.tsx
@@ -64,7 +64,7 @@ function SpaceDetailSheet({ open, space, onClose, copyId }: SpaceDetailSheetProp
               </div>
             ) : (
               <div className='space-y-6'>
-                <SpaceCardEligibilityPanel spaceId={id} active={tab === 'overview'} />
+                <SpaceCardEligibilityPanel spaceId={id} active={tab === 'overview'} detail={detail} />
                 <SpaceDetailContent detail={detail} copyId={copyId} />
               </div>
             )}

--- a/src/components/page/space/components/tabs/SpaceCardEligibilityPanel.tsx
+++ b/src/components/page/space/components/tabs/SpaceCardEligibilityPanel.tsx
@@ -1,10 +1,29 @@
 import { getSpaceCardEligibility } from '@/client/space';
+import type { SpaceDetail } from '@/client/types';
 import { Badge } from '@/components/ui/badge';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { Check, Loader2, X } from 'lucide-react';
+import type { ReactNode } from 'react';
 
-function SpaceCardEligibilityPanel({ spaceId, active }: { spaceId: string; active: boolean }) {
+function Metric({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className='min-w-0'>
+      <div className='text-xs text-slate-500'>{label}</div>
+      <div className='mt-0.5 truncate text-sm font-medium tabular-nums text-slate-900'>{value}</div>
+    </div>
+  );
+}
+
+function SpaceCardEligibilityPanel({
+  spaceId,
+  active,
+  detail,
+}: {
+  spaceId: string;
+  active: boolean;
+  detail: SpaceDetail;
+}) {
   const { data, isFetching } = useQuery({
     queryKey: ['space-card-eligibility', spaceId],
     queryFn: () => getSpaceCardEligibility(spaceId),
@@ -13,7 +32,7 @@ function SpaceCardEligibilityPanel({ spaceId, active }: { spaceId: string; activ
 
   if (isFetching && !data) {
     return (
-      <div className='flex min-h-[96px] items-center justify-center rounded-xl border border-slate-200/80 bg-white shadow-sm'>
+      <div className='flex min-h-[120px] items-center justify-center rounded-xl border border-slate-200/80 bg-white shadow-sm'>
         <Loader2 className='h-5 w-5 animate-spin text-muted-foreground' />
       </div>
     );
@@ -21,53 +40,68 @@ function SpaceCardEligibilityPanel({ spaceId, active }: { spaceId: string; activ
   if (!data) return null;
 
   const blockedReasons = data.checks.filter((c) => !c.passed);
+  const latestText = detail.latestCardIssuedAt
+    ? dayjs(detail.latestCardIssuedAt).format('YY.MM.DD HH:mm')
+    : '발급 없음';
+  const participationText = data.lastCard ? `${data.lastCard.replyCount}/${data.activeMembers} 답변` : '첫 카드';
 
   return (
-    <section className='space-y-2'>
+    <section className='space-y-3'>
       <div className='flex flex-wrap items-center gap-x-3 gap-y-1'>
         <h3 className='text-base font-semibold text-slate-900'>카드 발급 상태</h3>
         <Badge variant={data.canIssue ? 'softSuccess' : 'softWarning'}>
           {data.canIssue ? '발급 가능' : '발급 차단됨'}
         </Badge>
-        <span className='text-xs text-slate-500'>
-          현재 #{data.cardOrder} · 활성 멤버 {data.activeMembers}명
-          {data.nextGenAt ? ` · 다음 예정 ${dayjs(data.nextGenAt).format('YY.MM.DD')}` : ''}
-        </span>
       </div>
 
-      {/* 차단 사유를 맨 위에서 한눈에 */}
-      {blockedReasons.length ? (
-        <div className='rounded-xl border border-amber-200 bg-amber-50 px-4 py-3'>
-          <div className='text-xs font-medium text-amber-700'>차단 사유</div>
-          <ul className='mt-1 space-y-0.5'>
-            {blockedReasons.map((c) => (
-              <li key={c.key} className='text-sm font-medium text-amber-800'>
-                {c.detail ?? c.label}
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-
-      {/* 전체 게이트 체크리스트 */}
-      <div className='divide-y divide-slate-100 rounded-xl border border-slate-200/80 bg-white px-4 shadow-sm'>
-        {data.checks.map((check) => (
-          <div key={check.key} className='flex items-start gap-3 py-3'>
-            <span
-              className={
-                check.passed
-                  ? 'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-600'
-                  : 'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-rose-50 text-rose-600'
-              }
-            >
-              {check.passed ? <Check className='h-3 w-3' /> : <X className='h-3 w-3' />}
-            </span>
-            <div className='min-w-0'>
-              <div className='text-sm font-medium text-slate-900'>{check.label}</div>
-              {!check.passed && check.detail ? <div className='text-xs text-slate-500'>{check.detail}</div> : null}
-            </div>
+      <div className='grid gap-4 lg:grid-cols-2'>
+        {/* 카드 현황 — 상세 정보에 흩어져 있던 카드 항목을 취합 */}
+        <div className='rounded-xl border border-slate-200/80 bg-white p-4 shadow-sm'>
+          <div className='mb-3 text-xs font-medium text-slate-500'>카드 현황</div>
+          <div className='grid grid-cols-2 gap-x-4 gap-y-3'>
+            <Metric label='현재 카드' value={`#${data.cardOrder}`} />
+            <Metric label='활성 멤버' value={`${data.activeMembers}명`} />
+            <Metric label='발급 시각' value={detail.spaceInfo?.noticeTime || '-'} />
+            <Metric label='다음 생성 기준' value={data.nextGenAt ?? '-'} />
+            <Metric label='최근 발급' value={latestText} />
+            <Metric label='직전 카드 참여' value={participationText} />
           </div>
-        ))}
+        </div>
+
+        {/* 발급 조건 — 차단 사유 + 게이트 체크리스트 */}
+        <div className='rounded-xl border border-slate-200/80 bg-white shadow-sm'>
+          <div className='px-4 pt-3 text-xs font-medium text-slate-500'>발급 조건</div>
+          {blockedReasons.length ? (
+            <div className='mx-4 mt-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2'>
+              <ul className='space-y-0.5'>
+                {blockedReasons.map((c) => (
+                  <li key={c.key} className='text-sm font-medium text-amber-800'>
+                    {c.detail ?? c.label}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          <div className='mt-1 divide-y divide-slate-100 px-4'>
+            {data.checks.map((check) => (
+              <div key={check.key} className='flex items-start gap-3 py-2.5'>
+                <span
+                  className={
+                    check.passed
+                      ? 'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-600'
+                      : 'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-rose-50 text-rose-600'
+                  }
+                >
+                  {check.passed ? <Check className='h-3 w-3' /> : <X className='h-3 w-3' />}
+                </span>
+                <div className='min-w-0'>
+                  <div className='text-sm font-medium text-slate-900'>{check.label}</div>
+                  {!check.passed && check.detail ? <div className='text-xs text-slate-500'>{check.detail}</div> : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
…etail panel

Card eligibility panel now spans full width with a left '카드 현황' metrics grid (현재 카드/활성 멤버/발급 시각/다음 생성 기준/최근 발급/직전 참여) and a right gate checklist. Removed the card-related rows from 상세 정보 to avoid duplication.