### PR TITLE
fix(banner): unwrap { items } from locations endpoint to stop crash

### DIFF
--- a/src/client/banner.ts
+++ b/src/client/banner.ts
@@ -26,9 +26,10 @@ export type BannerLocation = {
 };
 
 export async function getBannerLocations() {
-  const res = await client.get<BannerLocation[]>('/banner/locations');
+  // Backend wraps the array as `{ items }` (admin.controller.ts) — unwrap to the array.
+  const res = await client.get<{ items: BannerLocation[] }>('/banner/locations');
 
-  return res.data;
+  return res.data.items;
 }
 
 export async function createBanner(params: CreateBannerParams) {

--- a/src/components/page/banner/useBannerLocations.ts
+++ b/src/components/page/banner/useBannerLocations.ts
@@ -8,6 +8,8 @@ export type BannerLocationOption = { value: string; label: string };
 // React Query dedupes by key, so multiple consumers share one request.
 export function useBannerLocations(): BannerLocationOption[] {
   const { data } = useQuery({ queryKey: ['banner-locations'], queryFn: getBannerLocations });
+  // Guard against a non-array response so a contract drift degrades to an empty dropdown, not a crash.
+  if (!Array.isArray(data)) return [];
 
-  return (data ?? []).map((location) => ({ value: location.key, label: location.label }));
+  return data.map((location) => ({ value: location.key, label: location.label }));
 }


### PR DESCRIPTION
GET /admin/banner/locations returns { items: [...] }, but the client assumed a bare array, so useBannerLocations ran .map on the object and crashed the banner page (white screen). Unwrap res.data.items and guard with Array.isArray so any future contract drift degrades to an empty dropdown instead of a crash.