### PR TITLE
fix(bubble): allow levels past 12 and unify the animal list

### DIFF
--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -270,7 +270,9 @@ export type CreateSnackParams = {
   isActive: boolean;
 };
 
-export type PetType = 'dog' | 'cat' | 'rebbit' | 'squirrel' | 'bear' | 'hamster' | 'chick' | 'penguin';
+// Mirrors the server's PetType enum. `deer` and `pig` existed there but were missing
+// here, so no admin screen could assign them.
+export type PetType = 'dog' | 'cat' | 'rebbit' | 'squirrel' | 'bear' | 'hamster' | 'chick' | 'penguin' | 'deer' | 'pig';
 export type PetTypeForCustom = PetType | 'null';
 
 export type GetSnacksResult = {
@@ -859,14 +861,7 @@ export type UserPushRow = {
   createdAt: string;
 };
 
-export type LiveSubscriptionStatus =
-  | 'active'
-  | 'grace'
-  | 'billingRetry'
-  | 'expired'
-  | 'revoked'
-  | 'canceled'
-  | 'error';
+export type LiveSubscriptionStatus = 'active' | 'grace' | 'billingRetry' | 'expired' | 'revoked' | 'canceled' | 'error';
 
 export type LiveSubscriptionRow = {
   id: number;

--- a/src/components/page/bubble/BubbleForm.tsx
+++ b/src/components/page/bubble/BubbleForm.tsx
@@ -1,6 +1,7 @@
 import { createBubble, updateBubble } from '@/client/bubble';
 import { BubbleType, Locale, PetBubble } from '@/client/types';
 import { LOCALE_OPTIONS } from '@/components/shared/form/constants/locale-options';
+import { MAX_PET_LEVEL } from '@/components/shared/form/constants/pet-options';
 import FormGroup from '@/components/shared/form/ui/form-group';
 import FormSection from '@/components/shared/form/ui/form-section';
 import { Button } from '@/components/ui/button';
@@ -29,9 +30,11 @@ const typeOptions = [
   { label: '커스텀', value: 'custom' },
 ];
 
-const levelOptions = Array(13)
+// The list stopped at 12 — one short of 13, the level where the pet's animal is decided —
+// so no bubble could be authored for an evolved pet.
+const levelOptions = Array(MAX_PET_LEVEL + 1)
   .fill(0)
-  .map((_, idx) => ({ label: String(idx), value: idx }));
+  .map((_, idx) => ({ label: idx === 0 ? '전체' : String(idx), value: idx }));
 
 const bubbleSchema = z.object({
   locale: z.string().min(1, '언어를 선택해주세요.'),
@@ -132,7 +135,10 @@ function BubbleForm({ init, reload, close }: Props) {
       )}
       <Form {...form}>
         <form onSubmit={form.handleSubmit(save)} className='space-y-4 pb-2'>
-          <FormSection title={focusedId ? '말풍선 수정' : '말풍선 추가'} description='메시지, 타입, 레벨 조건을 설정합니다.'>
+          <FormSection
+            title={focusedId ? '말풍선 수정' : '말풍선 추가'}
+            description='메시지, 타입, 레벨 조건을 설정합니다.'
+          >
             <FormGroup title='언어*'>
               <FormField
                 control={form.control}

--- a/src/components/page/bubble/BubbleList.tsx
+++ b/src/components/page/bubble/BubbleList.tsx
@@ -2,6 +2,7 @@ import { removeBubble } from '@/client/bubble';
 import { BubbleType, PetBubble } from '@/client/types';
 import AdminSideSheetContent from '@/components/shared/ui/admin-side-sheet-content';
 import DataTable from '@/components/shared/ui/data-table';
+import { PET_LEVEL_VALUES } from '@/components/shared/form/constants/pet-options';
 import { FILTER_CONTROL_CLASS, FilterBar } from '@/components/shared/ui/filter-bar';
 import TableRowActions from '@/components/shared/ui/table-row-actions';
 import {
@@ -199,7 +200,7 @@ function BubbleList() {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value='__all__'>전체</SelectItem>
-            {Array.from({ length: 10 }, (_, index) => index + 1).map((level) => (
+            {PET_LEVEL_VALUES.map((level) => (
               <SelectItem key={level} value={String(level)}>
                 Lv.{level}
               </SelectItem>

--- a/src/components/page/custom/constants.ts
+++ b/src/components/page/custom/constants.ts
@@ -1,4 +1,5 @@
 import { PetTypeForCustom } from '@/client/types';
+import { PET_TYPE_OPTIONS } from '@/components/shared/form/constants/pet-options';
 
 export const PetCustomTypeOptions = [
   { label: '효과', value: 'effect' },
@@ -13,12 +14,5 @@ export const premiumOptions = [
 
 export const petTypeOptions: { label: string; value: PetTypeForCustom }[] = [
   { label: '전체', value: 'null' },
-  { label: '곰', value: 'bear' },
-  { label: '고양이', value: 'cat' },
-  { label: '강아지', value: 'dog' },
-  { label: '펭귄', value: 'penguin' },
-  { label: '병아리', value: 'chick' },
-  { label: '토끼', value: 'rebbit' },
-  { label: '햄스터', value: 'hamster' },
-  { label: '다람쥐', value: 'squirrel' },
+  ...PET_TYPE_OPTIONS,
 ];

--- a/src/components/page/snack/SnackForm.tsx
+++ b/src/components/page/snack/SnackForm.tsx
@@ -1,5 +1,6 @@
 import { createSnack, updateSnack } from '@/client/snack';
 import { ImgItem, PetType, Snack, SnackKind } from '@/client/types';
+import { PET_TYPE_OPTIONS } from '@/components/shared/form/constants/pet-options';
 import FormGroup from '@/components/shared/form/ui/form-group';
 import FormSection from '@/components/shared/form/ui/form-section';
 import { Button } from '@/components/ui/button';
@@ -25,16 +26,7 @@ const KIND_OPTIONS: { label: string; value: SnackKind }[] = [
   { label: 'special', value: 'special' },
 ];
 
-const TYPE_OPTIONS: { label: string; value: PetType }[] = [
-  { label: '곰', value: 'bear' },
-  { label: '고양이', value: 'cat' },
-  { label: '강아지', value: 'dog' },
-  { label: '펭귄', value: 'penguin' },
-  { label: '병아리', value: 'chick' },
-  { label: '토끼', value: 'rebbit' },
-  { label: '햄스터', value: 'hamster' },
-  { label: '다람쥐', value: 'squirrel' },
-];
+const TYPE_OPTIONS = PET_TYPE_OPTIONS;
 
 const PREMIUM_OPTIONS = [
   { label: '스타', value: 'true' },
@@ -143,7 +135,10 @@ function SnackForm({ initialSnack, close, reload }: Props) {
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(save)} className='space-y-4 pb-2'>
-          <FormSection title={initialSnack ? '간식 수정' : '간식 추가'} description='이미지, 스탯, 노출 옵션을 설정합니다.'>
+          <FormSection
+            title={initialSnack ? '간식 수정' : '간식 추가'}
+            description='이미지, 스탯, 노출 옵션을 설정합니다.'
+          >
             <FormGroup title='대표 이미지*' description='리스트와 상세 화면에 노출됩니다.'>
               <div className='flex flex-col gap-2 items-start'>
                 {image && (
@@ -194,7 +189,11 @@ function SnackForm({ initialSnack, close, reload }: Props) {
                 render={({ field }) => (
                   <FormItem>
                     <FormControl>
-                      <RadioGroup value={field.value} onValueChange={field.onChange} className='grid grid-cols-2 gap-2 sm:grid-cols-4'>
+                      <RadioGroup
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        className='grid grid-cols-2 gap-2 sm:grid-cols-4'
+                      >
                         {KIND_OPTIONS.map((opt) => (
                           <div key={opt.value}>
                             <RadioGroupItem value={opt.value} id={`kind-${opt.value}`} className='peer sr-only' />
@@ -221,7 +220,11 @@ function SnackForm({ initialSnack, close, reload }: Props) {
                 render={({ field }) => (
                   <FormItem>
                     <FormControl>
-                      <RadioGroup value={field.value ?? ''} onValueChange={field.onChange} className='grid grid-cols-2 gap-2 sm:grid-cols-4'>
+                      <RadioGroup
+                        value={field.value ?? ''}
+                        onValueChange={field.onChange}
+                        className='grid grid-cols-2 gap-2 sm:grid-cols-4'
+                      >
                         {TYPE_OPTIONS.map((opt) => (
                           <div key={opt.value}>
                             <RadioGroupItem value={opt.value} id={`type-${opt.value}`} className='peer sr-only' />

--- a/src/components/page/space/utils/space-display.ts
+++ b/src/components/page/space/utils/space-display.ts
@@ -1,18 +1,10 @@
 import dayjs from 'dayjs';
 import type { Room } from '@/client/types';
+import { PET_TYPE_LABELS } from '@/components/shared/form/constants/pet-options';
 
 export function getPetTypeLabel(type?: string | null) {
-  const map: Record<string, string> = {
-    dog: '강아지',
-    cat: '고양이',
-    rebbit: '토끼',
-    squirrel: '다람쥐',
-    bear: '곰',
-    hamster: '햄스터',
-    chick: '병아리',
-    penguin: '펭귄',
-  };
-  return type ? map[type] ?? type : null;
+  const map: Record<string, string> = PET_TYPE_LABELS;
+  return type ? (map[type] ?? type) : null;
 }
 
 export function buildRoomCategorySummary(rooms?: Room[]) {
@@ -53,9 +45,15 @@ export function getMemberStatus(p: {
   removed?: boolean;
   renew?: boolean;
   removedAt?: string | null;
-}): { key: SpaceMemberStatusKey; label: string; badgeVariant: 'dotDanger' | 'dotWarning' | 'dotNeutral' | null; date: string | null } {
+}): {
+  key: SpaceMemberStatusKey;
+  label: string;
+  badgeVariant: 'dotDanger' | 'dotWarning' | 'dotNeutral' | null;
+  date: string | null;
+} {
   if (p.removed) return { key: 'removed', label: '삭제 대기', badgeVariant: 'dotDanger', date: p.removedAt ?? null };
-  if (p.disabled && p.renew) return { key: 'renewPending', label: '재가입 대기', badgeVariant: 'dotWarning', date: null };
+  if (p.disabled && p.renew)
+    return { key: 'renewPending', label: '재가입 대기', badgeVariant: 'dotWarning', date: null };
   if (p.disabled) return { key: 'left', label: '나감', badgeVariant: 'dotNeutral', date: p.removedAt ?? null };
   return { key: 'active', label: '활성', badgeVariant: null, date: null };
 }

--- a/src/components/shared/form/constants/pet-options.ts
+++ b/src/components/shared/form/constants/pet-options.ts
@@ -1,0 +1,37 @@
+import type { PetType } from '@/client/types';
+
+/**
+ * Pet levels run 1..MAX_PET_LEVEL. 0 is a sentinel meaning "applies to every level".
+ *
+ * 16 matches the ceiling the pet custom form already enforces. Levels are ultimately
+ * data-driven by the exp rules, so raise this if that table grows — both the bubble form
+ * and the bubble list filter read it, and they must not drift apart again: the form used
+ * to stop at 12 and the filter at 10, which made levels 13+ unauthorable and 11+
+ * unfilterable.
+ */
+export const MAX_PET_LEVEL = 16;
+
+/** 1..MAX, for filters that have their own separate "all" entry. */
+export const PET_LEVEL_VALUES = Array.from({ length: MAX_PET_LEVEL }, (_, index) => index + 1);
+
+/**
+ * The single list of animals, in the server enum's order. Four screens each kept their
+ * own copy and all four had drifted — every one of them was missing 사슴 and 돼지, so
+ * those two could not be picked anywhere in the admin.
+ */
+export const PET_TYPE_LABELS: Record<PetType, string> = {
+  dog: '강아지',
+  cat: '고양이',
+  rebbit: '토끼',
+  squirrel: '다람쥐',
+  bear: '곰',
+  hamster: '햄스터',
+  chick: '병아리',
+  penguin: '펭귄',
+  deer: '사슴',
+  pig: '돼지',
+};
+
+export const PET_TYPE_OPTIONS: { label: string; value: PetType }[] = (Object.keys(PET_TYPE_LABELS) as PetType[]).map(
+  (value) => ({ label: PET_TYPE_LABELS[value], value }),
+);


### PR DESCRIPTION
말풍선 could not be authored for level 13 or above: the form's level checkboxes were built from Array(13), so they stopped at 12 — one short of 13, which is the level where confirmPetType decides the pet's animal. The list's level filter was capped even lower, at Lv.10, so a level-13 bubble would also have been unfindable. Both now read one MAX_PET_LEVEL constant (16, matching the ceiling the pet custom form enforces) so they cannot drift apart again. Level 0 is also labelled 전체 rather than 0, since that meaning only appeared in helper text.

The animal list was hardcoded in four places — the PetType union, the snack form, the pet custom constants and the space list's label map — and every one of them was missing 사슴 and 돼지, which the server enum has had all along. Neither could be picked anywhere in the admin. All four now derive from one table.

Bubbles still carry no animal of their own; that needs a column on PetBuble and is deliberately not part of this change.


Claude-Session: https://claude.ai/code/session_01GmkAizfVU3DuM4H7nFqpNW